### PR TITLE
Adding node 12 support for db-browser-db2

### DIFF
--- a/nodeServer/package.json
+++ b/nodeServer/package.json
@@ -9,7 +9,7 @@
     "start": "tsc --watch"
   },
   "dependencies": {
-    "ibm_db": "^2.4.0",
+    "ibm_db": "~2.6.3",
     "@types/express": "~4.11.0",
     "@types/node": "~6.0.60",
     "typescript": "~2.5.3"


### PR DESCRIPTION
This will add node 12 support for the zlux-editor.
The build will not fail for lts versions now.
This solves zowe/zlux#391 for db-browser-db-2